### PR TITLE
Update cloudbuild-trigger-cd.yaml

### DIFF
--- a/cloudbuild-trigger-cd.yaml
+++ b/cloudbuild-trigger-cd.yaml
@@ -61,7 +61,7 @@ steps:
   args:
   - '-c'
   - |
-     sed "s/GOOGLE_CLOUD_PROJECT/${PROJECT_ID}/g" kubernetes.yaml.tpl | \
+     sed "s/GOOGLE_CLOUD_PROJECT/${PROJECT_ID}/g" hello-cloudbuild-env/kubernetes.yaml.tpl | \
      sed "s/COMMIT_SHA/${SHORT_SHA}/g" > hello-cloudbuild-env/kubernetes.yaml
 
 # This step pushes the manifest back to hello-cloudbuild-env


### PR DESCRIPTION
Without the correct directory here, there's no way for the template to populate the kubernetes configuration file, and then the environment build process fails.