### PR TITLE
Correct kubectl deployment cluster region

### DIFF
--- a/cloudbuild-delivery.yaml
+++ b/cloudbuild-delivery.yaml
@@ -23,7 +23,7 @@ steps:
   - '-f'
   - 'kubernetes.yaml'
   env:
-  - 'CLOUDSDK_COMPUTE_ZONE=us-central1-b'
+  - 'CLOUDSDK_COMPUTE_REGION=us-central1'
   - 'CLOUDSDK_CONTAINER_CLUSTER=hello-cloudbuild'
 
 # This step copies the applied manifest to the production branch


### PR DESCRIPTION
Change CLOUDSDK_COMPUTE_ZONE=us-central1-b to
CLOUDSDK_COMPUTE_REGION=us-central1 to match the cluster creation command in the
tutorial [0]:

```
gcloud container clusters create-auto hello-cloudbuild \
    --region us-central1
```

Otherwise, Cloud Build would fail with this error:

```
Step #0 - "Deploy": ERROR: (gcloud.container.clusters.get-credentials) ResponseError: code=404, message=Not found: projects/my-project/zones/us-central1-b/clusters/hello-cloudbuild.
Step #0 - "Deploy": Could not find [hello-cloudbuild] in [us-central1-b].
Step #0 - "Deploy": Did you mean [hello-cloudbuild] in [us-central1]?
```

0: https://cloud.google.com/kubernetes-engine/docs/tutorials/gitops-cloud-build