### PR TITLE
Use AR instead of GCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ popular in the Kubernetes community. A key part of GitOps is the idea of
 example, Kubernetes manifests) stored in a Git repository.
 
 In this tutorial, you create a CI/CD pipeline that automatically builds a
-container image from commited code, stores the image in Google Container
+container image from commited code, stores the image in Google Artifact
 Registry, updates a Kubernetes manifest in a Git repository and triggers a
 deployment to Kubernetes Engine using that manifest.
 
 This tutorial uses two Git repositories: one for the application —the _app_
 repository— and one for storing the deployment manifests —the _env_ repository.
 When a change is pushed to the application repository, tests are run, a
-container image is built and pushed to Container Registry. Once the image is
+container image is built and pushed to Artifact Registry. Once the image is
 pushed, the deployment manifests are updated to use that new image and they are
 pushed to the _candidate_ branch of the _env_ repository. This triggers the actual
 deployment in Kubernetes. Once the deployment is finished, the new manifests

--- a/cloudbuild-trigger-cd.yaml
+++ b/cloudbuild-trigger-cd.yaml
@@ -28,17 +28,17 @@ steps:
   args:
   - 'build'
   - '-t'
-  - 'gcr.io/$PROJECT_ID/hello-cloudbuild:$SHORT_SHA'
+  - 'us-central1-docker.pkg.dev/$PROJECT_ID/my-repository/hello-cloudbuild:$SHORT_SHA'
   - '.'
 
-# This step pushes the image to Container Registry
+# This step pushes the image to Artifact Registry
 # The PROJECT_ID and SHORT_SHA variables are automatically
 # replaced by Cloud Build.
 - name: 'gcr.io/cloud-builders/docker'
   id: Push
   args:
   - 'push'
-  - 'gcr.io/$PROJECT_ID/hello-cloudbuild:$SHORT_SHA'
+  - 'us-central1-docker.pkg.dev/$PROJECT_ID/my-repository/hello-cloudbuild:$SHORT_SHA'
 # [END cloudbuild]
 
 # [START cloudbuild-trigger-cd]
@@ -74,7 +74,7 @@ steps:
     set -x && \
     cd hello-cloudbuild-env && \
     git add kubernetes.yaml && \
-    git commit -m "Deploying image gcr.io/${PROJECT_ID}/hello-cloudbuild:${SHORT_SHA}
+    git commit -m "Deploying image us-central1-docker.pkg.dev/$PROJECT_ID/my-repository/hello-cloudbuild:${SHORT_SHA}
     Built from commit ${COMMIT_SHA} of repository hello-cloudbuild-app
     Author: $(git log --format='%an <%ae>' -n 1 HEAD)" && \
     git push origin candidate

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -28,15 +28,15 @@ steps:
   args:
   - 'build'
   - '-t'
-  - 'gcr.io/$PROJECT_ID/hello-cloudbuild:$SHORT_SHA'
+  - 'us-central1-docker.pkg.dev/$PROJECT_ID/my-repository/hello-cloudbuild:$SHORT_SHA'
   - '.'
 
-# This step pushes the image to Container Registry
+# This step pushes the image to Artifact Registry
 # The PROJECT_ID and SHORT_SHA variables are automatically
 # replaced by Cloud Build.
 - name: 'gcr.io/cloud-builders/docker'
   id: Push
   args:
   - 'push'
-  - 'gcr.io/$PROJECT_ID/hello-cloudbuild:$SHORT_SHA'
+  - 'us-central1-docker.pkg.dev/$PROJECT_ID/my-repository/hello-cloudbuild:$SHORT_SHA'
 # [END cloudbuild]

--- a/kubernetes.yaml.tpl
+++ b/kubernetes.yaml.tpl
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: hello-cloudbuild
-        image: gcr.io/GOOGLE_CLOUD_PROJECT/hello-cloudbuild:COMMIT_SHA
+        image: us-central1-docker.pkg.dev/GOOGLE_CLOUD_PROJECT/my-repository/hello-cloudbuild:COMMIT_SHA
         ports:
         - containerPort: 8080
 ---


### PR DESCRIPTION
## Background

* AR = Artifact Registry
* GCR = Google Container Registry
* See Google-internal bug: [b/203651280](https://b.corp.google.com/issues/203651280)
* See Google-internal change: [cl/411822363](https://critique-ng.corp.google.com/cl/411822363)
* Before submitting [cl/411822363](https://critique-ng.corp.google.com/cl/411822363), we will need to merge this pull-request.
 
## Change Summary

* This pull-request replaces the use of [Google Container Registry](https://cloud.google.com/container-registry) with [Artifact Registry](https://cloud.google.com/artifact-registry). 

## Manually Tested 👍

* I went through the tutorial with the changes from this pull-request and [cl/411822363](https://critique-ng.corp.google.com/cl/411822363).
* See [cl/411822363](https://critique-ng.corp.google.com/cl/411822363) for more details about testing.  